### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Node modules and logs
+node_modules
+npm-debug.log*
+.next
+**/*.tsbuildinfo
+
+# Git
+.git
+.gitignore
+
+# Local env files
+.env
+.env.local
+.env.*.local
+
+Dockerfile
+docker-compose*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use official Node.js LTS image for building the app
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Production image
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Docker
+
+Build the Docker image:
+
+```bash
+docker build -t snow_score .
+```
+
+Run the container:
+
+```bash
+docker run -p 3000:3000 snow_score
+```


### PR DESCRIPTION
## Summary
- add Dockerfile with multi-stage build for Next.js
- ignore build and git files in `.dockerignore`
- document Docker usage in README

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68473fdb5cf083239d81309c0368e26f