### PR TITLE
Cache judging data and queue offline score submissions

### DIFF
--- a/lib/offlineQueue.ts
+++ b/lib/offlineQueue.ts
@@ -1,0 +1,66 @@
+export type ScoreSubmission = {
+  round_heat_id: number;
+  run_num: number;
+  personnel_id: number;
+  score: number;
+  athlete_id: number;
+};
+
+const STORAGE_KEY = "scoreSubmissionQueue";
+
+function readQueue(): ScoreSubmission[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? (JSON.parse(stored) as ScoreSubmission[]) : [];
+  } catch (err) {
+    console.error("Failed to read offline queue", err);
+    return [];
+  }
+}
+
+function writeQueue(queue: ScoreSubmission[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+  } catch (err) {
+    console.error("Failed to write offline queue", err);
+  }
+}
+
+export function enqueueScoreSubmission(action: ScoreSubmission) {
+  const queue = readQueue();
+  queue.push(action);
+  writeQueue(queue);
+}
+
+// Flush queued submissions when online. Returns number of successfully processed actions.
+export async function flushScoreQueue(): Promise<number> {
+  if (typeof window === "undefined" || !navigator.onLine) return 0;
+
+  const queue = readQueue();
+  let processed = 0;
+
+  while (queue.length > 0) {
+    const action = queue[0];
+    try {
+      const response = await fetch("/api/scores-dj18dh12gpdi1yd89178tsadji1289", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(action),
+      });
+      if (!response.ok) {
+        // Stop processing if server returns error
+        break;
+      }
+      queue.shift();
+      processed += 1;
+    } catch (err) {
+      console.error("Failed to submit queued score", err);
+      // likely offline again
+      break;
+    }
+  }
+
+  writeQueue(queue);
+  return processed;
+}


### PR DESCRIPTION
## Summary
- cache athletes and best score data in localStorage so judging panel functions offline
- track connectivity and periodically flush queued score submissions when back online
- queue score submissions automatically if offline or network fails

## Testing
- `npm test` *(fails: SyntaxError in Playwright test setup)*
- `npm run lint` *(fails: multiple lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_6890dd1b37508323974e04c8a735e5b6