### PR TITLE
Add round progression and deletion controls

### DIFF
--- a/app/api/delete-round/route.ts
+++ b/app/api/delete-round/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import getDbPool from "@/lib/db";
+
+export async function DELETE(req: NextRequest) {
+  const roundIdParam = req.nextUrl.searchParams.get("round_id");
+  if (!roundIdParam) {
+    return NextResponse.json({ error: "Missing round_id" }, { status: 400 });
+  }
+  const roundId = parseInt(roundIdParam);
+  if (isNaN(roundId)) {
+    return NextResponse.json({ error: "Invalid round_id" }, { status: 400 });
+  }
+  const pool = getDbPool();
+  try {
+    // Remove heats for this round first to maintain FK integrity
+    await pool.query("DELETE FROM ss_heat_details WHERE round_id = $1", [roundId]);
+    await pool.query("DELETE FROM ss_round_details WHERE round_id = $1", [roundId]);
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (err) {
+    console.error("Error deleting round:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/components/manage-round-heat/RoundHeatManagementDisplay.tsx
+++ b/components/manage-round-heat/RoundHeatManagementDisplay.tsx
@@ -83,8 +83,18 @@ export default function RoundHeatManagementDisplay(
     setEditingIndex(null);
   }
 
-  function addRound() {
+  async function addRound() {
     if (isAddingRound.current) return;
+    // If another round is being edited, save it before adding
+    if (editingIndex !== null) {
+      try {
+        await saveRound(editingIndex);
+      } catch {
+        // If saving fails, do not proceed with adding a new round
+        return;
+      }
+    }
+
     isAddingRound.current = true;
 
     try {
@@ -114,6 +124,60 @@ export default function RoundHeatManagementDisplay(
       toast.error("Failed to add a new round.");
     } finally {
       isAddingRound.current = false;
+    }
+  }
+
+  async function progressRound(roundId: number) {
+    try {
+      const res = await fetch(`/api/make-round-progress?source_round_id=${roundId}`);
+      if (!res.ok) throw new Error("Failed to make round progress");
+      toast.success("Round progressed");
+    } catch (err) {
+      console.error(err);
+      toast.error("Unable to progress round");
+    }
+  }
+
+  async function deleteRound(index: number) {
+    const round = roundArray[index];
+    try {
+      if (round.round_id > 0) {
+        const res = await fetch(`/api/delete-round?round_id=${round.round_id}`, {
+          method: "DELETE",
+        });
+        if (!res.ok) throw new Error("Failed to delete round");
+      }
+
+      const updated = roundArray
+        .filter((_, i) => i !== index)
+        .map((r, i) => ({
+          ...r,
+          round_num: i + 1,
+          round_sequence: i + 1,
+        }));
+      setRoundArray(updated);
+      setEditingIndex(null);
+      setDirtyMap({});
+      setOriginalRounds({});
+
+      // Persist updated ordering
+      const payload = updated.map((r, i) => ({
+        ...r,
+        round_num: i + 1,
+        round_sequence: i + 1,
+      }));
+      if (payload.length > 0) {
+        const saveRes = await fetch("/api/add-update-rounds-and-heats", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!saveRes.ok) throw new Error("Failed to update round order");
+      }
+      toast.success("Round deleted");
+    } catch (err) {
+      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Error deleting round");
     }
   }
 
@@ -198,7 +262,7 @@ export default function RoundHeatManagementDisplay(
                   >
                     {isEditing ? "Cancel" : "Edit"}
                   </button>
-                  {isEditing && (
+                  {isEditing ? (
                     <button
                       className="btn btn-sm btn-success"
                       disabled={!isDirty}
@@ -206,6 +270,22 @@ export default function RoundHeatManagementDisplay(
                     >
                       Save
                     </button>
+                  ) : (
+                    <>
+                      <button
+                        className="btn btn-sm btn-secondary"
+                        disabled={round.round_id <= 0}
+                        onClick={() => progressRound(round.round_id)}
+                      >
+                        Progress
+                      </button>
+                      <button
+                        className="btn btn-sm btn-error"
+                        onClick={() => deleteRound(roundIndex)}
+                      >
+                        Delete
+                      </button>
+                    </>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add API endpoint for removing rounds
- allow progressing a round or deleting it from the management display
- ensure editing round is saved before adding a new one and renumber rounds after deletion

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6897a378126083238f5c125709485a2b